### PR TITLE
Added support for Holoeye SLMs

### DIFF
--- a/slmsuite/hardware/slms/holoeye.py
+++ b/slmsuite/hardware/slms/holoeye.py
@@ -89,18 +89,18 @@ class Holoeye(SLM):
         # Connect and open the SLM
         if verbose: print("Opening SLM ...", end="")
         self.preselect = preselect
-        self.slm = HEDS.SLM.Init(preselect=self.preselect)
-        self._handle_error(self.slm.errorCode())
+        self.slm_lib = HEDS.SLM.Init(preselect=self.preselect)
+        self._handle_error(self.slm_lib.errorCode())
         if verbose: print("success")
 
         # Set the SLM's operating wavelength (wav_um) in nm.
-        error = self.slm.setWavelength(wav_um * 1000)
+        error = self.slm_lib.setWavelength(wav_um * 1000)
         self._handle_error(error)
 
         # Check the SLM's parameters.
-        pitch_um = (self.slm.pixelsize_um(), self.slm.pixelsize_um())
-        width = self.slm.width_px()
-        height = self.slm.height_px()
+        pitch_um = (self.slm_lib.pixelsize_um(), self.slm_lib.pixelsize_um())
+        width = self.slm_lib.width_px()
+        height = self.slm_lib.height_px()
 
         # Instantiate the superclass
         super().__init__(
@@ -130,7 +130,7 @@ class Holoeye(SLM):
             If the error code is not HEDSERR_NoError.
         """
         if error != heds_types.HEDSERR_NoError:
-            raise RuntimeError(HEDS.SDK.ErrorString(self.slm.errorCode()))
+            raise RuntimeError(HEDS.SDK.ErrorString(self.slm_lib.errorCode()))
 
     @staticmethod
     def info(verbose=True):
@@ -153,7 +153,7 @@ class Holoeye(SLM):
         """
         See :meth:`.SLM.close`.
         """
-        error = self.slm.window().close()
+        error = self.slm_lib.window().close()
         self._handle_error(error)
 
     def _set_phase_hw(self, phase):
@@ -164,7 +164,7 @@ class Holoeye(SLM):
         :meth:`_set_phase_hw()`. See :meth:`.SLM._set_phase_hw` for further detail.
         """
         #2*pi is the standard phase assumed by Holoeye. The package slmsuite passes 8-bit greyscale to set_phase_hw
-        error = self.slm.showPhaseData(phase, phase_unit=256)
+        error = self.slm_lib.showPhaseData(phase, phase_unit=256)
         self._handle_error(error)
 
     def load_vendor_phase_correction(self, file_path):
@@ -180,12 +180,12 @@ class Holoeye(SLM):
             File path for the vendor-provided phase correction.
         """
         # Enable wavefront compensation visualization in SLM preview window and stay with SLM preview scale "Fit"
-        error = self.slm.preview().setSettings(
+        error = self.slm_lib.preview().setSettings(
             flags=heds_types.HEDSSLMPF_ShowWavefrontCompensation,
             zoom=0.0
         )
         self._handle_error(error)
 
         # Load the wavefront compensation file
-        error = self.slm.window().loadWavefrontCompensationFile(str(file_path))
+        error = self.slm_lib.window().loadWavefrontCompensationFile(str(file_path))
         self._handle_error(error)

--- a/slmsuite/hardware/slms/holoeye.py
+++ b/slmsuite/hardware/slms/holoeye.py
@@ -1,32 +1,36 @@
 """
 Hardware control for Holoeye SLMs.
-Tested with Holoeye SLM ERIS-NIR-153.
 Created for SLM Display SDK (Python) v4.0.0.
+Tested with Holoeye SLM ERIS-NIR-153.
 
 Important
 ~~~~
-Check that the SLM Display SDK is in the default folder C:\\Program Files\\HOLOEYE Photonics\\SLM Display SDK (Python) v4.0.0
-or otherwise add the installation folder to your PYTHON PATH as done below.
+Check that the SLM Display SDK is in the default folder
+``C:\\Program Files\\HOLOEYE Photonics\\SLM Display SDK`` (Python) v4.0.0
+or otherwise add the installation folder to your python path.
 """
 import warnings
 from .slm import SLM
 
-# Import the SLM Display SDK
-# If the SDK is not found, run the following lines in a python shell to define the module path for the Python API bindings
-# import os
-# import sys
-# env_path = os.getenv("HEDS_4_0_PYTHON")
-# if env_path is None or not os.path.isdir(env_path):
-#     env_path = os.path.abspath("../..")
-# importpath_api =  os.path.join(env_path, "api", "python")
-# importpath_HEDS =  os.path.join(env_path, "examples")
-# sys.path.append(importpath_api)
-# sys.path.append(importpath_HEDS)
+# Set the path for the SLM Display SDK
+import os
+import sys
+try:
+    env_path = os.getenv("HEDS_4_0_PYTHON")
+    if env_path is None or not os.path.isdir(env_path):
+        env_path = os.path.abspath("../..")
+    importpath_api =  os.path.join(env_path, "api", "python")
+    importpath_HEDS =  os.path.join(env_path, "examples")
+    sys.path.append(importpath_api)
+    sys.path.append(importpath_HEDS)
+except:
+    pass
 
 # Load Holoeye's SDK module.
 try:
     import HEDS
-    from hedslib.heds_types import *
+    # from hedslib.heds_types import *
+    from hedslib import heds_types
 except ImportError:
     HEDS = None
     warnings.warn("Holoeye SDK HEDS not installed. Install to use Holoeye SLMs.")
@@ -38,66 +42,63 @@ class Holoeye(SLM):
     Attributes
     ----------
     preselect : str
-        Preselect string for the SLM. Examples:
-        - "index:0"  // select first SLM available in the system.
-        - "name:pluto;serial:0001"  // select a PLUTO SLM with the serial number 0001.
-        - "name:luna"  // select a LUNA SLM.
-        - "serial:2220-0011"  // select a LUNA/2220 SLM just by passing the serial number.
+        Preselect string for the SLM. Used to identify the SLM.
     """
 
-    def __init__(self,verbose=True,preselect=None,wav_um=1,pitch_um=(8,8),**kwargs):
+    def __init__(
+        self,
+        preselect=None,
+        wav_um=1,
+        verbose=True,
+        **kwargs
+    ):
         r"""
         Initializes an instance of a Holoeye SLM.
 
-        Caution
-        ~~~~~~~
-        :class:`.Holoeye` defaults to 8 micron SLM pixel size.
-        This is valid for the PLUTO and ERIS models, but not true for all!
-
         Arguments
         ---------
-        verbose : bool
-            Whether to print extra information.
         preselect : str
             Preselect string for the SLM. Examples:
-            - "index:0"  // select first SLM available in the system.
-            - "name:pluto;serial:0001"  // select a PLUTO SLM with the serial number 0001.
-            - "name:luna"  // select a LUNA SLM.
-            - "serial:2220-0011"  // select a LUNA/2220 SLM just by passing the serial number.
-            - "connect://ipv4:port", e.g. "connect://127.0.0.1:6230" \\ connect to a manually started process  
+
+            - ``"index:0"`` select first SLM available in the system.
+            - ``"name:pluto;serial:0001"`` select a PLUTO SLM with the serial number 0001.
+            - ``"name:luna"`` select a LUNA SLM.
+            - ``"serial:2220-0011"`` select a LUNA/2220 SLM just by passing the serial number.
+            - ``"connect://ipv4:port"``, e.g. ``"connect://127.0.0.1:6230"``, connect to
+              a manually started process.
+
         wav_um : float
             Wavelength of operation in microns. Defaults to 1 um.
-        pitch_um : (float, float)
-            Pixel pitch in microns. Defaults to 8 micron square pixels (PLUTO and ERIS pixel size).
+        verbose : bool
+            Whether to print extra information.
         **kwargs
             See :meth:`.SLM.__init__` for permissible options.
 
         Important
         ~~~~~~~~
-        The Holoeye SLM Display SDK must be installed and the path to the SDK must be added to the PYTHON PATH.
-        Check the holoeye.py module file for instructions on how to do this.
+        The Holoeye SLM Display SDK must be installed and the path to the SDK must be added to the python path.
+        See :mod:`~slmsuite.hardware.slms.holoeye` for instructions on how to do this.
         """
-        
         if HEDS is None:
             raise ImportError("SDK HEDS not installed. Install to use Holoeye SLMs.")
-        
+
         # Initialize the SDK and check that version 4.0 of the SDK is being used.
         error = HEDS.SDK.Init(4,0)
         self._handle_error(error)
-        
+
         # Connect and open the SLM
         if verbose: print("Opening SLM ...", end="")
         self.preselect = preselect
         self.slm = HEDS.SLM.Init(preselect=self.preselect)
         self._handle_error(self.slm.errorCode())
-        if verbose: print("Success!")
-        
-        #Set the SLM's operating wavelength (wav_um) in nm.
-        error = self.slm.setWavelength(wav_um*1000)
+        if verbose: print("success")
+
+        # Set the SLM's operating wavelength (wav_um) in nm.
+        error = self.slm.setWavelength(wav_um * 1000)
         self._handle_error(error)
-        
-        #Check the SLM's parameters.
-        assert (self.slm.pixelsize_um(),self.slm.pixelsize_um()) == pitch_um, "Given pixel size does not match the SLM specifications."
+
+        # Check the SLM's parameters.
+        pitch_um = (self.slm.pixelsize_um(), self.slm.pixelsize_um())
         width = self.slm.width_px()
         height = self.slm.height_px()
 
@@ -117,17 +118,20 @@ class Holoeye(SLM):
         """
         Handles errors from the Holoeye SDK.
         Raises an exception if the error code is not HEDSERR_NoError.
+
         Parameters
         ----------
         error : int
             Error code returned by the Holoeye SDK.
+
         Raises
         ------
-        AssertionError
+        RuntimeError
             If the error code is not HEDSERR_NoError.
         """
-        assert error == HEDSERR_NoError, HEDS.SDK.ErrorString(self.slm.errorCode())
-        
+        if error != heds_types.HEDSERR_NoError:
+            raise RuntimeError(HEDS.SDK.ErrorString(self.slm.errorCode()))
+
     @staticmethod
     def info(verbose=True):
         """
@@ -138,6 +142,7 @@ class Holoeye(SLM):
         ----------
         verbose : bool
             Whether to print the discovered information.
+
         Raises
         ------
         NotImplementedError
@@ -162,19 +167,25 @@ class Holoeye(SLM):
         error = self.slm.showPhaseData(phase, phase_unit=256)
         self._handle_error(error)
 
-    def load_vendor_phase_correction(self, file):
+    def load_vendor_phase_correction(self, file_path):
         """
         Load phase correction provided by Holoeye from file,
-        setting ``"phase"`` in :attr:`~slmsuite.hardware.slms.slm.SLM.source`.
+        directly into the SLM SDK.
+        Note that this bypasses the slmsuite standard of setting
+        ``"phase"`` in :attr:`~slmsuite.hardware.slms.slm.SLM.source`.
 
         Parameters
         ----------
         file_path : str
             File path for the vendor-provided phase correction.
         """
-        #Enable wavefront compensation visualization in SLM preview window and stay with SLM preview scale "Fit"
-        error = self.slm.preview().setSettings(flags=HEDSSLMPF_ShowWavefrontCompensation,zoom=0.0)
+        # Enable wavefront compensation visualization in SLM preview window and stay with SLM preview scale "Fit"
+        error = self.slm.preview().setSettings(
+            flags=heds_types.HEDSSLMPF_ShowWavefrontCompensation,
+            zoom=0.0
+        )
         self._handle_error(error)
+
         # Load the wavefront compensation file
-        error = self.slm.window().loadWavefrontCompensationFile(str(file))
+        error = self.slm.window().loadWavefrontCompensationFile(str(file_path))
         self._handle_error(error)

--- a/slmsuite/hardware/slms/holoeye.py
+++ b/slmsuite/hardware/slms/holoeye.py
@@ -1,90 +1,110 @@
 """
-**(NotImplemented)** Hardware control for Holoeye SLMs.
-This is a partial skeleton that can be completed if desired.
+Hardware control for Holoeye SLMs.
+Tested with Holoeye SLM ERIS-NIR-153.
+Created for SLM Display SDK (Python) v4.0.0.
+
+Important
+~~~~
+Check that the SLM Display SDK is in the default folder C:\\Program Files\\HOLOEYE Photonics\\SLM Display SDK (Python) v4.0.0
+or otherwise add the installation folder to your PYTHON PATH as done below.
 """
-import os
 import warnings
 from .slm import SLM
 
-try:  # Load Holoeye's SDK module.
-    from holoeye import slmdisplaysdk
+# Import the SLM Display SDK
+# If the SDK is not found, run the following lines in a python shell to define the module path for the Python API bindings
+# import os
+# import sys
+# env_path = os.getenv("HEDS_4_0_PYTHON")
+# if env_path is None or not os.path.isdir(env_path):
+#     env_path = os.path.abspath("../..")
+# importpath_api =  os.path.join(env_path, "api", "python")
+# importpath_HEDS =  os.path.join(env_path, "examples")
+# sys.path.append(importpath_api)
+# sys.path.append(importpath_HEDS)
+
+# Load Holoeye's SDK module.
+try:
+    import HEDS
+    from hedslib.heds_types import *
 except ImportError:
-    slmdisplaysdk = None
-    warnings.warn("slmdisplaysdk not installed. Install to use Holoeye slms.")
+    HEDS = None
+    warnings.warn("Holoeye SDK HEDS not installed. Install to use Holoeye SLMs.")
 
 class Holoeye(SLM):
     """
-    Interfaces with Holoeye SLMs via the ``slmdisplaysdk``.
+    Interfaces with Holoeye SLMs via the the ``HEDS`` library.
 
     Attributes
     ----------
-    slm_lib : TODO
-        Object handle for the Holoeye SLM.
-    sdk_path : str
-        Path of the Blink SDK folder.
+    preselect : str
+        Preselect string for the SLM. Examples:
+        - "index:0"  // select first SLM available in the system.
+        - "name:pluto;serial:0001"  // select a PLUTO SLM with the serial number 0001.
+        - "name:luna"  // select a LUNA SLM.
+        - "serial:2220-0011"  // select a LUNA/2220 SLM just by passing the serial number.
     """
 
-    def __init__(
-        self,
-        verbose=True,
-        wav_um=1,
-        pitch_um=(8,8),
-        **kwargs
-    ):
+    def __init__(self,verbose=True,preselect=None,wav_um=1,pitch_um=(8,8),**kwargs):
         r"""
-        Initialize SLM and attributes.
+        Initializes an instance of a Holoeye SLM.
 
-        Parameters
-        ----------
+        Caution
+        ~~~~~~~
+        :class:`.Holoeye` defaults to 8 micron SLM pixel size.
+        This is valid for the PLUTO and ERIS models, but not true for all!
+
+        Arguments
+        ---------
+        verbose : bool
+            Whether to print extra information.
+        preselect : str
+            Preselect string for the SLM. Examples:
+            - "index:0"  // select first SLM available in the system.
+            - "name:pluto;serial:0001"  // select a PLUTO SLM with the serial number 0001.
+            - "name:luna"  // select a LUNA SLM.
+            - "serial:2220-0011"  // select a LUNA/2220 SLM just by passing the serial number.
+            - "connect://ipv4:port", e.g. "connect://127.0.0.1:6230" \\ connect to a manually started process  
         wav_um : float
             Wavelength of operation in microns. Defaults to 1 um.
         pitch_um : (float, float)
-            Pixel pitch in microns. Defaults to 8 micron square pixels.
+            Pixel pitch in microns. Defaults to 8 micron square pixels (PLUTO and ERIS pixel size).
         **kwargs
             See :meth:`.SLM.__init__` for permissible options.
 
-        Note
-        ~~~~
-        These arguments, which ultimately are used to instantiate the :class:`.SLM` superclass,
-        may be more accurately filled by calling the SLM's SDK functions.
-        See the other implemented SLM subclasses for examples.
+        Important
+        ~~~~~~~~
+        The Holoeye SLM Display SDK must be installed and the path to the SDK must be added to the PYTHON PATH.
+        Check the holoeye.py module file for instructions on how to do this.
         """
-        if slmdisplaysdk is None:
-            raise ImportError("slmdisplaysdk not installed. Install to use Holoeye slms.")
-
-        # Get the SLM.
-        if verbose: print("Creating SLM instance...", end="")
-        self.slm_lib = slmdisplaysdk.SLMInstance()  # ?
-        # self.slm_lib = slmdisplaysdk.SLMDisplay() # ?
-
-        # Check version somehow.
-        if self.slm_lib.requiresVersion(3):
-            if verbose: print("failure")
-            raise RuntimeError("TODO")
-        if verbose: print("success")
-
-        # Open the SLM.
-        if verbose: print("Opening SLM...", end="")
-        error = self.slm_lib.open()
-
-        if error != slmdisplaysdk.ErrorCode.NoError:
-            if verbose: print("failure")
-            self._handle_error(error)
-        if verbose: print("success")
-
-        # Other possibilities to consider:
-        # - Setting the SLM's operating wavelength (wav_um).
-        # - Updating the SLM's phase table if necessary, and/or setting the design
-        #   wavelength (wav_design_um).
-        # - Setting the SLM's default settle time (abstract class SLM uses
-        #   settle_time_s=0.3 seconds). This is important for experimental feedback to
-        #   allow the SLM to settle before viewing the result on a camera.
-        # - Checking for and saving the SLM parameters (height, width, etc).
+        
+        if HEDS is None:
+            raise ImportError("SDK HEDS not installed. Install to use Holoeye SLMs.")
+        
+        # Initialize the SDK and check that version 4.0 of the SDK is being used.
+        error = HEDS.SDK.Init(4,0)
+        self._handle_error(error)
+        
+        # Connect and open the SLM
+        if verbose: print("Opening SLM ...", end="")
+        self.preselect = preselect
+        self.slm = HEDS.SLM.Init(preselect=self.preselect)
+        self._handle_error(self.slm.errorCode())
+        if verbose: print("Success!")
+        
+        #Set the SLM's operating wavelength (wav_um) in nm.
+        error = self.slm.setWavelength(wav_um*1000)
+        self._handle_error(error)
+        
+        #Check the SLM's parameters.
+        assert (self.slm.pixelsize_um(),self.slm.pixelsize_um()) == pitch_um, "Given pixel size does not match the SLM specifications."
+        width = self.slm.width_px()
+        height = self.slm.height_px()
 
         # Instantiate the superclass
         super().__init__(
-            (self.slm_lib.width(), self.slm_lib.height()),
-            bitdepth=self.slm_lib.depth(),
+            (width, height),
+            bitdepth=8,
             wav_um=wav_um,
             pitch_um=pitch_um,
             **kwargs
@@ -94,9 +114,20 @@ class Holoeye(SLM):
         self.set_phase(None)
 
     def _handle_error(self, error):
-        if error != slmdisplaysdk.ErrorCode.NoError:
-            raise RuntimeError(self.slm_lib.errorString(error))
-
+        """
+        Handles errors from the Holoeye SDK.
+        Raises an exception if the error code is not HEDSERR_NoError.
+        Parameters
+        ----------
+        error : int
+            Error code returned by the Holoeye SDK.
+        Raises
+        ------
+        AssertionError
+            If the error code is not HEDSERR_NoError.
+        """
+        assert error == HEDSERR_NoError, HEDS.SDK.ErrorString(self.slm.errorCode())
+        
     @staticmethod
     def info(verbose=True):
         """
@@ -107,18 +138,18 @@ class Holoeye(SLM):
         ----------
         verbose : bool
             Whether to print the discovered information.
-
-        Returns
-        --------
-        list of str
-            List of serial numbers or identifiers.
+        Raises
+        ------
+        NotImplementedError
         """
-        if slmdisplaysdk is None:
-            raise ImportError("slmdisplaysdk not installed. Install to use Holoeye slms.")
+        raise NotImplementedError("This functionality is not supported by Holoeye. Use the EDID device detection GUI instead.")
 
-        raise NotImplementedError()
-        serial_list = get_serial_list()     # TODO: Fill in proper function.
-        return serial_list
+    def close(self):
+        """
+        See :meth:`.SLM.close`.
+        """
+        error = self.slm.window().close()
+        self._handle_error(error)
 
     def _set_phase_hw(self, phase):
         """
@@ -127,5 +158,23 @@ class Holoeye(SLM):
         :class:`.SLM`, ``phase`` is error checked before calling
         :meth:`_set_phase_hw()`. See :meth:`.SLM._set_phase_hw` for further detail.
         """
-        error = self.slm_lib.showData(phase, self.flags)
+        #2*pi is the standard phase assumed by Holoeye. The package slmsuite passes 8-bit greyscale to set_phase_hw
+        error = self.slm.showPhaseData(phase, phase_unit=256)
+        self._handle_error(error)
+
+    def load_vendor_phase_correction(self, file):
+        """
+        Load phase correction provided by Holoeye from file,
+        setting ``"phase"`` in :attr:`~slmsuite.hardware.slms.slm.SLM.source`.
+
+        Parameters
+        ----------
+        file_path : str
+            File path for the vendor-provided phase correction.
+        """
+        #Enable wavefront compensation visualization in SLM preview window and stay with SLM preview scale "Fit"
+        error = self.slm.preview().setSettings(flags=HEDSSLMPF_ShowWavefrontCompensation,zoom=0.0)
+        self._handle_error(error)
+        # Load the wavefront compensation file
+        error = self.slm.window().loadWavefrontCompensationFile(str(file))
         self._handle_error(error)


### PR DESCRIPTION
Hi Ian,

I have added support for Holoeye SLMs with SLM Display SDK Version 4.0 and tested it with our ERIS-NIR-153 SLM.  With version 4 of the SDK, Holoeye introduced a new Library API for more convenient programming. I wrote the module for the new SDK version (as of 09/2024), making use of the HEDS library instead of the slmdisplaysdk library.

To use the Holoeye SLM with this module, it is important that the folder of the SLM Display SDK is added to the PYTHON PATH environment variable. Instructions and a short code snippet on how to do this are included in comments at the beginning of the module. The device initialization opens an SLM automatically if it is uniquely described by the _preselect_ keyword argument or manually via Holoeye's EDID Device Detection if no (unique) _preselect_ is given. Once initialized, the manufacturer-supplied wavefront calibration file can be loaded via the _load_vendor_phase_correction_ method by passing its filepath.

Let me know, if you have any questions or if you would like some changes to the code.

Best regards,
Maximilian