### PR TITLE
Fixes a few bugs and an inconsistency in the updated meadowlark.py for 3.0.0

### DIFF
--- a/slmsuite/hardware/slms/meadowlark.py
+++ b/slmsuite/hardware/slms/meadowlark.py
@@ -283,9 +283,9 @@ class Meadowlark(SLM):
             (
                 board,
                 f"{Meadowlark._get_serial(mode, board)} "
-                f"({Meadowlark._get_width(mode, board)}"
-                f"x{Meadowlark._get_height(mode, board)},"
-                f", {Meadowlark._get_bitdepth(mode, board)}-bit)"
+                f"({Meadowlark._get_width(mode, board)}x"
+                f"{Meadowlark._get_height(mode, board)}, "
+                f"{Meadowlark._get_bitdepth(mode, board)}-bit)"
             )
             for board in range(1, Meadowlark._number_of_boards[mode] + 1)
         ]

--- a/slmsuite/hardware/slms/meadowlark.py
+++ b/slmsuite/hardware/slms/meadowlark.py
@@ -622,7 +622,7 @@ class Meadowlark(SLM):
                 )
 
         # If we got to here, we need to actually load the SDK.
-        if len(cases) >= 1:
+        if len(cases) > 1:
             options = ',\n'.join([f'{_SDK_MODE_NAMES[case[0]]} ({case[1]})' for case in cases])
             warnings.warn(
                 f"Multiple Meadowlark SDKs located. "

--- a/slmsuite/hardware/slms/meadowlark.py
+++ b/slmsuite/hardware/slms/meadowlark.py
@@ -327,7 +327,7 @@ class Meadowlark(SLM):
         """
         sdk = Meadowlark._slm_lib[sdk_mode]
         if sdk_mode == _SDK_MODE.HDMI:
-            return sdk.slm_lib.Get_Width()
+            return sdk.Get_Width()
         elif (
             sdk_mode == _SDK_MODE.PCIE_LEGACY
             or sdk_mode == _SDK_MODE.PCIE_MODERN
@@ -379,7 +379,7 @@ class Meadowlark(SLM):
         """
         sdk = Meadowlark._slm_lib[sdk_mode]
         if sdk_mode == _SDK_MODE.HDMI:
-            return sdk.slm_lib.Get_Depth()
+            return sdk.Get_Depth()
         elif (
             sdk_mode == _SDK_MODE.PCIE_LEGACY
             or sdk_mode == _SDK_MODE.PCIE_MODERN

--- a/slmsuite/hardware/slms/meadowlark.py
+++ b/slmsuite/hardware/slms/meadowlark.py
@@ -808,7 +808,7 @@ class Meadowlark(SLM):
         # Finally, actually load the LUT file
         try:
             if self.sdk_mode == _SDK_MODE.HDMI:
-                Meadowlark._slm_lib[self.sdk_mode].Load_LUT(lut_path)
+                Meadowlark._slm_lib[self.sdk_mode].Load_lut(lut_path)
             elif (
                 self.sdk_mode == _SDK_MODE.PCIE_LEGACY
                 or self.sdk_mode == _SDK_MODE.PCIE_MODERN


### PR DESCRIPTION
Hi,

I’m upgrading to the 3.0.0 prerelease to use the new crosshair feature in the camera viewer. While doing so, I encountered issues with the Meadowlark interface — it doesn’t work out of the box with our Meadowlark HDMI 1920x1200 8-bit SLM.

To get it working, I had to make the following changes:

1. Update sdk.slm_lib to sdk in get_depth and get_width
→ Seems like this was accidentally left unchanged?
2. Change Load_LUT to Load_lut in Meadowlark._slm_lib[self.sdk_mode]
→ Possibly due to an API change in the Meadowlark DLL?
3. Modify the warning about multiple SDKs
→ Now only shows if more than one SDK is actually found. This one might be debatable — if we keep the check, we might want to revise the warning message for clarity.

@darikoneil @nobias — could you please confirm point 2? Was this a change in the DLL?