### PR TITLE
Adds centroid (center of mass) crosshair widget to camera viewer

### DIFF
--- a/slmsuite/hardware/cameras/camera.py
+++ b/slmsuite/hardware/cameras/camera.py
@@ -1249,8 +1249,8 @@ class _CameraViewer:
             "scale" : scale,
             "border" : border,
             "cmap_options" : cmap_options,
-            "crosshair" : crosshair,
-            "centroid" : centroid,
+            "center_crosshair" : crosshair,
+            "centroid_crosshair" : centroid,
         }
 
         self.task = None
@@ -1274,7 +1274,7 @@ class _CameraViewer:
         else:
             img = np.copy(self.prev_img)
 
-        if self.state["centroid"]:
+        if self.state["centroid_crosshair"]:
             img_median_subtract = image_remove_field([img], deviations=None)
             cx, cy = np.rint(image_centroids(img_median_subtract) * self.state["scale"]).astype(int)
 
@@ -1302,12 +1302,12 @@ class _CameraViewer:
             rgb = zoom(rgb, (1, self.state["scale"], self.state["scale"], 1), order=0)
 
         # Add crosshair at the median-subtracted centroid (center of mass) position.
-        if self.state["centroid"]:
+        if self.state["centroid_crosshair"]:
             rgb[:, :, cx, :3] = 255 - rgb[:, :, cx, :3]
             rgb[:, cy, :, :3] = 255 - rgb[:, cy, :, :3]
 
         # Finally, add crosshair in the center.
-        if self.state["crosshair"]:
+        if self.state["center_crosshair"]:
             rgb[:, :, int(rgb.shape[2]/2), :3] = 255 - rgb[:, :, int(rgb.shape[2]/2), :3]
             rgb[:, int(rgb.shape[1]/2), :, :3] = 255 - rgb[:, int(rgb.shape[1]/2), :, :3]
 
@@ -1327,7 +1327,7 @@ class _CameraViewer:
     def update(self, event):
         with self.widgets["output"]:
             self.widgets["output"].clear_output(wait=True)
-        for key in ["range", "log", "cmap", "scale", "live", "crosshair", "centroid"]:
+        for key in ["range", "log", "cmap", "scale", "live", "center_crosshair", "centroid_crosshair"]:
             self.state[key] = self.widgets[key].value
 
         self.render()
@@ -1413,15 +1413,15 @@ class _CameraViewer:
                 tooltip="Toggle logarithmic scaling of the current plot.",
                 layout=item_layout,
             ),
-            "crosshair" : Checkbox(
-                value=self.state["crosshair"],
-                description="Crosshair",
+            "center_crosshair" : Checkbox(
+                value=self.state["center_crosshair"],
+                description="Center Crosshair",
                 tooltip="Toggle a crosshair centered on the image.",
                 layout=item_layout,
             ),
-            "centroid" : Checkbox(
-                value=self.state["centroid"],
-                description="Centroid",
+            "centroid_crosshair" : Checkbox(
+                value=self.state["centroid_crosshair"],
+                description="Centroid Crosshair",
                 tooltip="Toggle a crosshair at the median-subtracted centroid (center of mass) of the image.",
                 layout=item_layout,
             ),
@@ -1492,8 +1492,8 @@ class _CameraViewer:
                     HBox([
                         self.widgets["cmap"],
                         self.widgets["log"],
-                        self.widgets["crosshair"],
-                        self.widgets["centroid"],
+                        self.widgets["center_crosshair"],
+                        self.widgets["centroid_crosshair"],
                     ]),
                     HBox([
                         self.widgets["range"],

--- a/slmsuite/hardware/cameras/camera.py
+++ b/slmsuite/hardware/cameras/camera.py
@@ -1523,7 +1523,7 @@ class _CameraViewer:
         p = np.sum(image)
         hh = np.arange(h)
         vv = np.arange(v)
-        xc = np.sum(np.dot(image, hh)) / p
-        yc = np.sum(np.dot(image.T, vv)) / p
+        yc = np.sum(np.dot(image.T, hh)) / p
+        xc = np.sum(np.dot(image, vv)) / p
 
         return np.round((xc, yc)).astype(int)


### PR DESCRIPTION
We might want to discuss

1. if we name the feature "centroid" or "center of mass"
2. if we rename "crosshair" to "center" as both are sort of crosshairs
3. if we move the helper function `centroid` out of `_CameraViewer`
4. change the implementation of `centroid`