### PR TITLE
Fixes FourierSLMs calibration getting modified by ijcam_to_knmslm() transformation.

### DIFF
--- a/slmsuite/holography/algorithms/_feedback.py
+++ b/slmsuite/holography/algorithms/_feedback.py
@@ -181,8 +181,8 @@ class FeedbackHologram(Hologram):
         b1 = np.matmul(M1, -toolbox.format_2vectors(np.flip(np.squeeze(self.shape)) / 2))
 
         # Second transformation.
-        M2 = self.cameraslm.calibrations["fourier"]["M"]
-        b2 = self.cameraslm.calibrations["fourier"]["b"]
+        M2 = self.cameraslm.calibrations["fourier"]["M"].copy()
+        b2 = self.cameraslm.calibrations["fourier"]["b"].copy()
         if "a" in self.cameraslm.calibrations["fourier"]:
             b2 -= np.matmul(M2, self.cameraslm.calibrations["fourier"]["a"])
 


### PR DESCRIPTION
When calculating the ijcam_to_knmslm() transformation for any given image,
the fourier calibration saved within the FourierSLM object is also modified.
I added the .copy(), so b2 and the FourierSLMs b aren't linked.
To be thorough I also added this to the M2, however it shouldn't matter in this case.