### PR TITLE
Fixed the Hamamatsu SLM functionality, no working close function

### DIFF
--- a/slmsuite/hardware/slms/hamamatsu.py
+++ b/slmsuite/hardware/slms/hamamatsu.py
@@ -173,7 +173,6 @@ class Hamamatsu(SLM):
             conform with eventual implementation of this feature in other SLMs.
         """
         array_size = int(self.shape[0] * self.shape[1])
-        array = display.astype(c_uint8)  # TODO: check if this is necessary
 
         write_fmemarray = Lcoslib.Write_FMemArray
         write_fmemarray.argtyes = [c_uint8, c_uint8*array_size, c_int32, c_uint32, c_uint32, c_uint32]
@@ -181,7 +180,7 @@ class Hamamatsu(SLM):
         # TODO: do python ints need to be converted explicitly to c_uint32?
         v = write_fmemarray(
             self.board_id,
-            array.ctypes.data_as(POINTER(c_uint8* array_size)).contents,
+            display.ctypes.data_as(POINTER(c_uint8* array_size)).contents,
             array_size,
             self.shape[1],
             self.shape[0],
@@ -211,7 +210,6 @@ class Hamamatsu(SLM):
         Reads the current displayed pattern from the SLM.
         """
         display = np.zeros(self.shape, dtype=np.uint8)
-        array = display.astype(c_uint8)  # TODO: check if this is necessary
         array_size = int(self.shape[0] * self.shape[1])
 
         get_display = Lcoslib.Get_Display
@@ -221,7 +219,7 @@ class Hamamatsu(SLM):
             array_size,
             self.shape[1],
             self.shape[0],
-            array.ctypes.data_as(POINTER(c_uint8* array_size)).contents,
+            display.ctypes.data_as(POINTER(c_uint8* array_size)).contents,
         )
 
         if v != 1:

--- a/slmsuite/hardware/slms/hamamatsu.py
+++ b/slmsuite/hardware/slms/hamamatsu.py
@@ -379,7 +379,7 @@ class Hamamatsu(SLM):
         if v != 1:
             raise RuntimeError(f"Could not check Hamamatsu temperature (error={v}).")
 
-        return (float(head_temperature), float(controller_temperature))
+        return (head_temperature.value, controller_temperature.value)
 
     def get_led_status(self):
         r"""

--- a/slmsuite/hardware/slms/hamamatsu.py
+++ b/slmsuite/hardware/slms/hamamatsu.py
@@ -3,7 +3,7 @@ Hardware control for Hamamatsu SLMs in USB/Trigger mode.
 For DVI mode, reset the SLM to DVI mode externally and
 project information onto the appropriate screen using
 :class:`~slmsuite.hardware.slms.screenmirrored.ScreenMirrored`.
-A previous version was tested with Hamamatsu LCOS-SLM X15213-02.
+Tested with Hamamatsu LCOS-SLM X15213.
 
 Important
 ~~~~~~~~~

--- a/slmsuite/hardware/slms/hamamatsu.py
+++ b/slmsuite/hardware/slms/hamamatsu.py
@@ -172,7 +172,7 @@ class Hamamatsu(SLM):
             this variable may be renamed in a future slmsuite release to
             conform with eventual implementation of this feature in other SLMs.
         """
-        array_size = int(self.shape[1] * self.shape[1])
+        array_size = int(self.shape[0] * self.shape[1])
         array = display.astype(c_uint8)  # TODO: check if this is necessary
 
         write_fmemarray = Lcoslib.Write_FMemArray
@@ -277,7 +277,7 @@ class Hamamatsu(SLM):
         if v != 1:
             raise RuntimeError("Failed to read Hamamatsu SLM mode.")
 
-        return int(mode)
+        return mode.value
 
     @staticmethod
     def _Reboot(board_id):
@@ -325,6 +325,13 @@ class Hamamatsu(SLM):
 
         if v != 1:
             raise RuntimeError("Failed to close Hamamatsu device.")
+        
+    def close(self) -> None:
+        """
+        This needs to exist, but I haven't gotten this to work yet.
+        #TODO: Write a proper close function
+        """
+        pass
 
     @staticmethod
     def _Check_HeadSerial(board_id):

--- a/slmsuite/hardware/slms/hamamatsu.py
+++ b/slmsuite/hardware/slms/hamamatsu.py
@@ -1,9 +1,9 @@
 """
-**(Untested)** Hardware control for Hamamatsu SLMs in USB/Trigger mode.
+Hardware control for Hamamatsu SLMs in USB/Trigger mode.
 For DVI mode, reset the SLM to DVI mode externally and
 project information onto the appropriate screen using
 :class:`~slmsuite.hardware.slms.screenmirrored.ScreenMirrored`.
-A previous verions was tested with Hamamatsu LCOS-SLM X15213-02.
+A previous version was tested with Hamamatsu LCOS-SLM X15213-02.
 
 Important
 ~~~~~~~~~
@@ -101,26 +101,26 @@ class Hamamatsu(SLM):
 
         if n_dev == 0:
             raise RuntimeError("No Hamamatsu devices found!")
+
+        if verbose: print("success")
+
+        # Read the serial number of the device.
+        if serial_number is None:
+            if verbose: print(f"Looking for SLM...", end="")
         else:
-            if verbose: print("success")
+            if verbose: print(f"Looking for '{serial_number}'...", end="")
 
-            # Read the serial number of the device.
-            if serial_number is None:
-                if verbose: print(f"Looking for SLM...", end="")
+        self.serial_number = self._Check_HeadSerial(board_id=self.board_id)
+
+        # Error if the desired serial number is not found.
+        if serial_number is not None:
+            if serial_number in self.serial_number or self.serial_number in serial_number:
+                pass
             else:
-                if verbose: print(f"Looking for '{serial_number}'...", end="")
+                self._Close_Device(board_ids, bID_size=1)
+                raise RuntimeError(f"Could not find '{serial_number}'. Found '{self.serial_number}'.")
 
-            self.serial_number = self._Check_HeadSerial(board_id=self.board_id)
-
-            # Error if the desired serial number is not found.
-            if serial_number is not None:
-                if serial_number in self.serial_number or self.serial_number in serial_number:
-                    pass
-                else:
-                    self._Close_Device(board_ids, bID_size=1)
-                    raise RuntimeError(f"Could not find '{serial_number}'. Found '{self.serial_number}'.")
-
-            if verbose: print("success")
+        if verbose: print("success")
 
         # Force the SLM to USB/Trigger mode.
         try:
@@ -212,7 +212,7 @@ class Hamamatsu(SLM):
         """
         display = np.zeros(self.shape, dtype=np.uint8)
         array = display.astype(c_uint8)  # TODO: check if this is necessary
-        array_size = int(self.shape[1] * self.shape[1])
+        array_size = int(self.shape[0] * self.shape[1])
 
         get_display = Lcoslib.Get_Display
         get_display.argtyes = [c_uint8, c_int32, c_uint32, c_uint32, c_uint8*array_size]
@@ -325,13 +325,12 @@ class Hamamatsu(SLM):
 
         if v != 1:
             raise RuntimeError("Failed to close Hamamatsu device.")
-        
+
     def close(self) -> None:
         """
-        This needs to exist, but I haven't gotten this to work yet.
-        #TODO: Write a proper close function
+        Closes the connection to the SLM device.
         """
-        pass
+        self._Close_Device(bID_list=[self.board_id], bID_size=1)
 
     @staticmethod
     def _Check_HeadSerial(board_id):

--- a/slmsuite/hardware/slms/hamamatsu.py
+++ b/slmsuite/hardware/slms/hamamatsu.py
@@ -330,7 +330,8 @@ class Hamamatsu(SLM):
         """
         Closes the connection to the SLM device.
         """
-        self._Close_Device(bID_list=[self.board_id], bID_size=1)
+        bID_list = (c_uint8 * len([self.board_id]))(*[self.board_id])
+        self._Close_Device(bID_list=bID_list, bID_size=1)
 
     @staticmethod
     def _Check_HeadSerial(board_id):

--- a/slmsuite/hardware/slms/hamamatsu.py
+++ b/slmsuite/hardware/slms/hamamatsu.py
@@ -214,7 +214,7 @@ class Hamamatsu(SLM):
         array = display.astype(c_uint8)  # TODO: check if this is necessary
         array_size = int(self.shape[1] * self.shape[1])
 
-        get_display = Lcoslib.Get_Display
+        get_display = Lcoslib.Check_Disp_IMG
         get_display.argtyes = [c_uint8, c_int32, c_uint32, c_uint32, c_uint8*array_size]
         v = get_display(
             self.board_id,


### PR DESCRIPTION
I implemented a couple minor changes in order to use the Hamamatsu SLM via USB.
In order:
- Added an a close function, because it needs to exist.
- Fixed the type conversion of the mode variable
- Fixed the array_size
I also replaced line 176 [array = display.astype(c_uint8)  # TODO: check if this is necessary] with [array = display] and it seems like the conversion isn't necessary. From what I've seen it doesn't even convert the data-type anyway.