### PR TITLE
Changed default random_phase value from True to False in `holo.reset_phase()`

### DIFF
--- a/slmsuite/holography/algorithms/_hologram.py
+++ b/slmsuite/holography/algorithms/_hologram.py
@@ -590,7 +590,7 @@ class Hologram(_HologramStats):
                 if "random_phase" in self.flags:
                     random_phase = self.flags["random_phase"]
                 else:
-                    random_phase = 1
+                    random_phase = False
 
             self.phase.fill(0)
 


### PR DESCRIPTION
Before, if you wanted to use a different phase option, like a quadratic phase, the random phase would also be active and act on top of the requested phase pattern. I don't believe this to be intentional.